### PR TITLE
Added function `from_uri` to create context from URI

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -36,6 +36,19 @@ impl Context {
         Ok(Context { ctx, })
     }
 
+    /// Tries to create a context from the specified URI
+    pub fn from_uri(uri: &str) -> Result<Context> {
+        let uri = match CString::new(uri) {
+            Ok(v) => v,
+            Err(_e) => bail!("Can't create context from URI {}", uri),
+        };
+        let ctx = unsafe {
+            ffi::iio_create_context_from_uri(uri.as_ptr())
+        };
+        if ctx.is_null() { bail!(SysError(Errno::last())); }
+        Ok(Context{ ctx, })
+    }
+
     /// Get a description of the context
     pub fn description(&self) -> String {
         let pstr = unsafe { ffi::iio_context_get_description(self.ctx) };


### PR DESCRIPTION
This pull request adds a function from_uri to Context which allows the creation of a IIO context using a URI string.
I have updated the error handling such that it doesn't panic and hopefully provides a meaningful error message.