### PR TITLE
Some memory safety fixes

### DIFF
--- a/examples/iio_detect.rs
+++ b/examples/iio_detect.rs
@@ -23,16 +23,14 @@ fn main() {
 
     if ctx.num_devices() == 0 {
         println!("No devices in the default IIO context");
-    }
-    else {
+    } else {
         println!("IIO Devices:");
         for dev in ctx.devices() {
             if dev.is_trigger() {
                 if let Some(id) = dev.id() {
                     trigs.push(id);
                 }
-            }
-            else {
+            } else {
                 print!("  {} ", dev.id().unwrap_or_default());
                 print!("[{}]", dev.name().unwrap_or_default());
                 println!(": {} channel(s)", dev.num_channels());
@@ -47,4 +45,3 @@ fn main() {
         }
     }
 }
-

--- a/examples/iio_free_scan.rs
+++ b/examples/iio_free_scan.rs
@@ -14,7 +14,7 @@
 extern crate industrial_io as iio;
 use std::process;
 
-const DFLT_DEV_NAME: &'static str = "44e0d000.tscadc:adc";
+const DFLT_DEV_NAME: &str = "44e0d000.tscadc:adc";
 
 
 fn main() {
@@ -45,7 +45,7 @@ fn main() {
         process::exit(4);
     }
 
-    for mut chan in dev.channels() {
+    for chan in dev.channels() {
         let data: Vec<u16> = buf.channel_iter::<u16>(&chan).collect();
         println!("{}: {:?}", chan.id().unwrap_or_default(), data);
     }

--- a/examples/iio_free_scan.rs
+++ b/examples/iio_free_scan.rs
@@ -16,7 +16,6 @@ use std::process;
 
 const DFLT_DEV_NAME: &str = "44e0d000.tscadc:adc";
 
-
 fn main() {
     let dev_name = DFLT_DEV_NAME;
 
@@ -50,4 +49,3 @@ fn main() {
         println!("{}: {:?}", chan.id().unwrap_or_default(), data);
     }
 }
-

--- a/examples/iio_readraw.rs
+++ b/examples/iio_readraw.rs
@@ -15,7 +15,7 @@ fn main() -> iio::Result<()> {
 
     for chan in dev.channels() {
         if chan.id() != Some("timestamp".to_string()) {
-            print!("{} ", chan.id().unwrap_or(unknown.clone()));
+            print!("{} ", chan.id().unwrap_or_else(|| unknown.clone()));
         }
     }
     println!();
@@ -24,17 +24,13 @@ fn main() -> iio::Result<()> {
         tick.recv().unwrap();
         for chan in dev.channels() {
             if chan.id() == Some("timestamp".to_string()) {
-            }
-            else {
-                if let Ok(val) = chan.attr_read_int("raw") {
-                    print!(" {:6}", val);
-                }
-                else {
-                    print!(" xxxxxx");
-                }
+            } else if let Ok(val) = chan.attr_read_int("raw") {
+                print!(" {:6}", val);
+            } else {
+                print!(" xxxxxx");
             }
         }
-        println!("");
+        println!();
     }
 }
 

--- a/examples/iio_readraw.rs
+++ b/examples/iio_readraw.rs
@@ -3,8 +3,8 @@
 extern crate industrial_io as iio;
 extern crate schedule_recv;
 
-use std::time::Duration;
 use schedule_recv::periodic;
+use std::time::Duration;
 
 fn main() -> iio::Result<()> {
     let ctx = iio::Context::new().expect("Couldn't open IIO Context");
@@ -33,4 +33,3 @@ fn main() -> iio::Result<()> {
         println!();
     }
 }
-

--- a/src/bin/iio_info_rs.rs
+++ b/src/bin/iio_info_rs.rs
@@ -27,7 +27,7 @@ fn main() -> iio::Result<()> {
     for dev in ctx.devices() {
         //assert_eq(ctx, dev.context());
         println!("\t{}: {}", dev.id().unwrap_or_default(),
-                 dev.name().unwrap_or("<unknown>".to_string()));
+                 dev.name().unwrap_or_else(|| "<unknown>".to_string()));
         println!("\t\t{} channels found:", dev.num_channels());
 
         for chan in dev.channels() {
@@ -45,7 +45,7 @@ fn main() -> iio::Result<()> {
                     println!("{}", val);
                 }
                 else {
-                    println!("");
+                    println!();
                 }
             }
         }

--- a/src/bin/iio_info_rs.rs
+++ b/src/bin/iio_info_rs.rs
@@ -15,7 +15,6 @@ extern crate industrial_io as iio;
 use std::process;
 
 fn main() -> iio::Result<()> {
-
     let ctx = iio::Context::new().unwrap_or_else(|err| {
         eprintln!("Error getting the IIO Context: {}", err);
         process::exit(1);
@@ -26,25 +25,28 @@ fn main() -> iio::Result<()> {
 
     for dev in ctx.devices() {
         //assert_eq(ctx, dev.context());
-        println!("\t{}: {}", dev.id().unwrap_or_default(),
-                 dev.name().unwrap_or_else(|| "<unknown>".to_string()));
+        println!(
+            "\t{}: {}",
+            dev.id().unwrap_or_default(),
+            dev.name().unwrap_or_else(|| "<unknown>".to_string())
+        );
         println!("\t\t{} channels found:", dev.num_channels());
 
         for chan in dev.channels() {
             println!("\t\t\t{}", chan.id().unwrap_or_default());
-            println!("\t\t\t{} channel-specific attributes found:", chan.num_attrs());
+            println!(
+                "\t\t\t{} channel-specific attributes found:",
+                chan.num_attrs()
+            );
             for attr in chan.attrs() {
                 print!("\t\t\t\t'{}' value: ", attr);
                 if let Ok(val) = chan.attr_read_float(&attr) {
                     println!("{}", val);
-                }
-                else if let Ok(val) = chan.attr_read_int(&attr) {
+                } else if let Ok(val) = chan.attr_read_int(&attr) {
                     println!("{}", val);
-                }
-                else if let Ok(val) = chan.attr_read_bool(&attr) {
+                } else if let Ok(val) = chan.attr_read_bool(&attr) {
                     println!("{}", val);
-                }
-                else {
+                } else {
                     println!();
                 }
             }
@@ -52,4 +54,3 @@ fn main() -> iio::Result<()> {
     }
     Ok(())
 }
-

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -10,16 +10,16 @@
 //! Industrial I/O Buffers
 //!
 
-use std::{mem, ptr};
 use std::marker::PhantomData;
+use std::{mem, ptr};
 
-use nix::errno::{Errno};
+use nix::errno::Errno;
 use nix::Error::Sys as SysError;
 
-use ffi;
-use errors::*;
-use context::*;
 use channel::*;
+use context::*;
+use errors::*;
+use ffi;
 
 /// An Industrial I/O input or output buffer
 pub struct Buffer {
@@ -34,7 +34,9 @@ impl Buffer {
     /// This is only valid for input buffers
     pub fn refill(&mut self) -> Result<usize> {
         let n = unsafe { ffi::iio_buffer_refill(self.buf) };
-        if n < 0 { bail!(SysError(Errno::last())); }
+        if n < 0 {
+            bail!(SysError(Errno::last()));
+        }
         Ok(n as usize)
     }
 
@@ -43,7 +45,9 @@ impl Buffer {
     /// This is only valid for output buffers
     pub fn push(&mut self) -> Result<usize> {
         let n = unsafe { ffi::iio_buffer_push(self.buf) };
-        if n < 0 { bail!(SysError(Errno::last())); }
+        if n < 0 {
+            bail!(SysError(Errno::last()));
+        }
         Ok(n as usize)
     }
 
@@ -53,7 +57,9 @@ impl Buffer {
     /// This is only valid for output buffers
     pub fn push_partial(&mut self, n: usize) -> Result<usize> {
         let n = unsafe { ffi::iio_buffer_push_partial(self.buf, n) };
-        if n < 0 { bail!(SysError(Errno::last())); }
+        if n < 0 {
+            bail!(SysError(Errno::last()));
+        }
         Ok(n as usize)
     }
 
@@ -63,7 +69,7 @@ impl Buffer {
             let begin = ffi::iio_buffer_first(self.buf, chan.chan) as *mut T;
             let end = ffi::iio_buffer_end(self.buf) as *const T;
             let ptr = begin;
-            let step: isize = ffi::iio_buffer_step(self.buf)/mem::size_of::<T>() as isize;
+            let step: isize = ffi::iio_buffer_step(self.buf) / mem::size_of::<T>() as isize;
 
             IntoIter {
                 phantom: PhantomData,
@@ -99,8 +105,7 @@ impl<T> Iterator for IntoIter<T> {
         unsafe {
             if self.ptr as *const _ >= self.end {
                 None
-            }
-            else {
+            } else {
                 let prev = self.ptr;
                 self.ptr = self.ptr.offset(self.step);
                 Some(ptr::read(prev))
@@ -108,5 +113,3 @@ impl<T> Iterator for IntoIter<T> {
         }
     }
 }
-
-

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -11,24 +11,25 @@
 //!
 
 use std::ffi::CString;
-use std::os::raw::{c_uint, c_longlong};
+use std::os::raw::{c_longlong, c_uint};
 
-use nix::errno::{Errno};
+use nix::errno::Errno;
 use nix::Error::Sys as SysError;
 
-use ffi;
 use super::*;
+use ffi;
 
 #[derive(Debug, PartialEq)]
 pub enum ChannelType {
     Input,
-    Output
+    Output,
 }
 
 /// An Industrial I/O Device Channel
 pub struct Channel {
     pub(crate) chan: *mut ffi::iio_channel,
-    #[allow(dead_code)]  // looks like it's unused, but really it's holding the Device's lifetime for libiio safety.
+    #[allow(dead_code)]
+    // looks like it's unused, but really it's holding the Device's lifetime for libiio safety.
     pub(crate) ctx: Context,
 }
 
@@ -151,10 +152,7 @@ impl Channel {
 
     /// Gets an iterator for the attributes of the channel
     pub fn attrs(&self) -> AttrIterator {
-        AttrIterator {
-            chan: self,
-            idx: 0
-        }
+        AttrIterator { chan: self, idx: 0 }
     }
 
     /// Enable the channel
@@ -174,7 +172,6 @@ impl Channel {
     pub fn is_enabled(&self) -> bool {
         unsafe { ffi::iio_channel_is_enabled(self.chan) }
     }
-
 }
 
 pub struct AttrIterator<'a> {
@@ -190,9 +187,8 @@ impl<'a> Iterator for AttrIterator<'a> {
             Ok(name) => {
                 self.idx += 1;
                 Some(name)
-            },
-            Err(_) => None
+            }
+            Err(_) => None,
         }
     }
 }
-

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -10,7 +10,7 @@
 //! Industrial I/O Channels
 //!
 
-use std::ffi::{CString, CStr};
+use std::ffi::CString;
 use std::os::raw::{c_uint, c_longlong};
 
 use nix::errno::{Errno};
@@ -61,7 +61,7 @@ impl Channel {
     /// Gets the channel-specific attribute at the index
     pub fn get_attr(&self, idx: usize) -> Result<String> {
         let pstr = unsafe { ffi::iio_channel_get_attr(self.chan, idx as c_uint) };
-        cstring_opt(pstr).ok_or("Invalid index".into())
+        cstring_opt(pstr).ok_or_else(|| "Invalid index".into())
     }
 
     /// Reads a channel-specific attribute as a boolean

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -28,6 +28,8 @@ pub enum ChannelType {
 /// An Industrial I/O Device Channel
 pub struct Channel {
     pub(crate) chan: *mut ffi::iio_channel,
+    #[allow(dead_code)]  // looks like it's unused, but really it's holding the Device's lifetime for libiio safety.
+    pub(crate) ctx: Context,
 }
 
 impl Channel {

--- a/src/context.rs
+++ b/src/context.rs
@@ -19,8 +19,6 @@ use nix::Error::Sys as SysError;
 
 use ffi;
 use super::*;
-use errors::*;
-use device::*;
 
 /// An Industrial I/O Context
 #[derive(Debug)]
@@ -53,7 +51,7 @@ impl Context {
     /// `timeout` The timeout. A value of zero specifies that no timeout
     /// should be used.
     pub fn set_timeout(&mut self, timeout: Duration) -> Result<()> {
-        let timeout_ms: u64 = 1000 * timeout.as_secs() + timeout.subsec_millis() as u64;
+        let timeout_ms: u64 = 1000 * timeout.as_secs() + u64::from(timeout.subsec_millis());
         let ret = unsafe { ffi::iio_context_set_timeout(self.ctx, timeout_ms as c_uint) };
         if ret < 0 { bail!(SysError(Errno::last())); }
         Ok(())

--- a/src/context.rs
+++ b/src/context.rs
@@ -13,6 +13,7 @@
 use std::time::Duration;
 use std::ffi::CString;
 use std::os::raw::c_uint;
+use std::rc::Rc;
 
 use nix::errno::{Errno};
 use nix::Error::Sys as SysError;
@@ -20,10 +21,27 @@ use nix::Error::Sys as SysError;
 use ffi;
 use super::*;
 
-/// An Industrial I/O Context
-#[derive(Debug)]
+/** An Industrial I/O Context
+Since IIO doesn't provide any thread safety guarantees, this object cannot be Send or Sync.
+This object maintains a reference counted pointer to the context object of the underlying library's iio_context object.
+Once all references to the Context object have been dropped, the underlying iio_context will be destroyed.
+This is done to make creation and use of a single Device more ergonomic by removing the need to manage the lifetime of the Context.
+**/
+#[derive(Debug,Clone)]
 pub struct Context {
-    pub(crate) ctx: *mut ffi::iio_context,
+    raw: Rc<RawContext>,
+}
+
+/// RawContext holds a 
+#[derive(Debug)]
+struct RawContext {
+    pub(crate) ctx: *mut ffi::iio_context
+}
+
+impl Drop for RawContext {
+    fn drop(&mut self) {
+        unsafe { ffi::iio_context_destroy(self.ctx) };
+    }
 }
 
 impl Context {
@@ -31,18 +49,18 @@ impl Context {
     pub fn new() -> Result<Context> {
         let ctx = unsafe { ffi::iio_create_default_context() };
         if ctx.is_null() { bail!(SysError(Errno::last())); }
-        Ok(Context { ctx, })
+        Ok(Context { raw: Rc::new(RawContext{ ctx }) })
     }
 
     /// Get a description of the context
     pub fn description(&self) -> String {
-        let pstr = unsafe { ffi::iio_context_get_description(self.ctx) };
+        let pstr = unsafe { ffi::iio_context_get_description(self.raw.ctx) };
         cstring_opt(pstr).unwrap_or_default()
     }
 
     /// Gets the number of context-specific attributes
     pub fn num_attrs(&self) -> usize {
-        let n = unsafe { ffi::iio_context_get_attrs_count(self.ctx) };
+        let n = unsafe { ffi::iio_context_get_attrs_count(self.raw.ctx) };
         n as usize
     }
 
@@ -52,34 +70,34 @@ impl Context {
     /// should be used.
     pub fn set_timeout(&mut self, timeout: Duration) -> Result<()> {
         let timeout_ms: u64 = 1000 * timeout.as_secs() + u64::from(timeout.subsec_millis());
-        let ret = unsafe { ffi::iio_context_set_timeout(self.ctx, timeout_ms as c_uint) };
+        let ret = unsafe { ffi::iio_context_set_timeout(self.raw.ctx, timeout_ms as c_uint) };
         if ret < 0 { bail!(SysError(Errno::last())); }
         Ok(())
     }
 
     /// Get the number of devices in the context
     pub fn num_devices(&self) -> usize {
-        let n = unsafe { ffi::iio_context_get_devices_count(self.ctx) };
+        let n = unsafe { ffi::iio_context_get_devices_count(self.raw.ctx) };
         n as usize
     }
 
     /// Gets a device by index
     pub fn get_device(&self, idx: usize) -> Result<Device> {
-        let dev = unsafe { ffi::iio_context_get_device(self.ctx, idx as c_uint) };
+        let dev = unsafe { ffi::iio_context_get_device(self.raw.ctx, idx as c_uint) };
         if dev.is_null() { bail!("Index out of range"); }
-        Ok(Device { dev, })
+        Ok(Device { dev, ctx: self.clone() })
     }
 
     /// Try to find a device by name or ID
     /// `name` The name or ID of the device to find
     pub fn find_device(&self, name: &str) -> Option<Device> {
         let name = CString::new(name).unwrap();
-        let dev = unsafe { ffi::iio_context_find_device(self.ctx, name.as_ptr()) };
+        let dev = unsafe { ffi::iio_context_find_device(self.raw.ctx, name.as_ptr()) };
         if dev.is_null() {
             None
         }
         else {
-            Some(Device { dev, })
+            Some(Device { dev, ctx: self.clone() })
         }
     }
 
@@ -97,25 +115,11 @@ impl Context {
     pub fn destroy(self) {}
 }
 
-impl Clone for Context {
-    fn clone(&self) -> Self {
-        let ctx = unsafe { ffi::iio_context_clone(self.ctx) };
-        if ctx.is_null() { panic!("Failed context clone"); }
-        Context { ctx, }
-    }
-}
-
 impl PartialEq for Context {
     /// Two contexts are the same if they refer to the same underlying
     /// object in the library.
     fn eq(&self, other: &Context) -> bool {
-        self.ctx == other.ctx
-    }
-}
-
-impl Drop for Context {
-    fn drop(&mut self) {
-        unsafe { ffi::iio_context_destroy(self.ctx) };
+        self.raw.ctx == other.raw.ctx
     }
 }
 

--- a/src/device.rs
+++ b/src/device.rs
@@ -11,13 +11,13 @@
 //!
 
 use std::ffi::CString;
-use std::os::raw::{c_uint, c_longlong};
+use std::os::raw::{c_longlong, c_uint};
 
-use nix::errno::{Errno};
+use nix::errno::Errno;
 use nix::Error::Sys as SysError;
 
-use ffi;
 use super::*;
+use ffi;
 
 /// An Industrial I/O Device
 ///
@@ -54,7 +54,9 @@ impl Device {
     /// `trigger` The device to be used as a trigger.
     pub fn set_trigger(&mut self, trigger: &Device) -> Result<()> {
         let ret = unsafe { ffi::iio_device_set_trigger(self.dev, trigger.dev) };
-        if ret < 0 { bail!(SysError(Errno::last())); }
+        if ret < 0 {
+            bail!(SysError(Errno::last()));
+        }
         Ok(())
     }
 
@@ -163,8 +165,13 @@ impl Device {
     /// Gets a channel by index
     pub fn get_channel(&self, idx: usize) -> Result<Channel> {
         let chan = unsafe { ffi::iio_device_get_channel(self.dev, idx as c_uint) };
-        if chan.is_null() { bail!("Index out of range"); }
-        Ok(Channel { chan, ctx: self.context() })
+        if chan.is_null() {
+            bail!("Index out of range");
+        }
+        Ok(Channel {
+            chan,
+            ctx: self.context(),
+        })
     }
 
     /// Try to find a channel by its name or ID
@@ -175,18 +182,17 @@ impl Device {
 
         if chan.is_null() {
             None
-        }
-        else {
-            Some(Channel { chan, ctx: self.context() })
+        } else {
+            Some(Channel {
+                chan,
+                ctx: self.context(),
+            })
         }
     }
 
     /// Gets an iterator for the channels in the device
     pub fn channels(&self) -> ChannelIterator {
-        ChannelIterator {
-            dev: self,
-            idx: 0,
-        }
+        ChannelIterator { dev: self, idx: 0 }
     }
 
     /// Creates a buffer for the device.
@@ -195,8 +201,13 @@ impl Device {
     /// `cyclic` Whether to enable cyclic mode.
     pub fn create_buffer(&self, sample_count: usize, cyclic: bool) -> Result<Buffer> {
         let buf = unsafe { ffi::iio_device_create_buffer(self.dev, sample_count, cyclic) };
-        if buf.is_null() { bail!(SysError(Errno::last())); }
-        Ok(Buffer { buf, ctx: self.context() })
+        if buf.is_null() {
+            bail!(SysError(Errno::last()));
+        }
+        Ok(Buffer {
+            buf,
+            ctx: self.context(),
+        })
     }
 }
 
@@ -221,8 +232,8 @@ impl<'a> Iterator for ChannelIterator<'a> {
             Ok(chan) => {
                 self.idx += 1;
                 Some(chan)
-            },
-            Err(_) => None
+            }
+            Err(_) => None,
         }
     }
 }
@@ -240,9 +251,8 @@ impl<'a> Iterator for AttrIterator<'a> {
             Ok(name) => {
                 self.idx += 1;
                 Some(name)
-            },
-            Err(_) => None
+            }
+            Err(_) => None,
         }
     }
 }
-

--- a/src/device.rs
+++ b/src/device.rs
@@ -10,7 +10,7 @@
 //! Industrial I/O Devices
 //!
 
-use std::ffi::{CString, CStr};
+use std::ffi::CString;
 use std::os::raw::{c_uint, c_longlong};
 
 use nix::errno::{Errno};
@@ -18,8 +18,6 @@ use nix::Error::Sys as SysError;
 
 use ffi;
 use super::*;
-use errors::*;
-use channel::*;
 
 /// An Industrial I/O Device
 ///
@@ -70,7 +68,7 @@ impl Device {
     /// Gets the name of the device-specific attribute at the index
     pub fn get_attr(&self, idx: usize) -> Result<String> {
         let pstr = unsafe { ffi::iio_device_get_attr(self.dev, idx as c_uint) };
-        cstring_opt(pstr).ok_or("Invalid index".into())
+        cstring_opt(pstr).ok_or_else(|| "Invalid index".into())
     }
 
     /// Reads a device-specific attribute as a boolean

--- a/src/device.rs
+++ b/src/device.rs
@@ -24,14 +24,13 @@ use super::*;
 /// This can not be created directly. It is obtained from a context.
 pub struct Device {
     pub(crate) dev: *mut ffi::iio_device,
+    pub(crate) ctx: Context,
 }
 
 impl Device {
     /// Gets the context to which the device belongs
     pub fn context(&self) -> Context {
-        let ctx = unsafe { ffi::iio_device_get_context(self.dev) as *mut ffi::iio_context };
-        if ctx.is_null() { panic!("Unexpected NULL context"); }
-        Context { ctx, }
+        self.ctx.clone()
     }
 
     /// Gets the device ID (e.g. <b><i>iio:device0</i></b>)
@@ -165,7 +164,7 @@ impl Device {
     pub fn get_channel(&self, idx: usize) -> Result<Channel> {
         let chan = unsafe { ffi::iio_device_get_channel(self.dev, idx as c_uint) };
         if chan.is_null() { bail!("Index out of range"); }
-        Ok(Channel { chan, })
+        Ok(Channel { chan, ctx: self.context() })
     }
 
     /// Try to find a channel by its name or ID
@@ -178,7 +177,7 @@ impl Device {
             None
         }
         else {
-            Some(Channel { chan, })
+            Some(Channel { chan, ctx: self.context() })
         }
     }
 
@@ -197,7 +196,7 @@ impl Device {
     pub fn create_buffer(&self, sample_count: usize, cyclic: bool) -> Result<Buffer> {
         let buf = unsafe { ffi::iio_device_create_buffer(self.dev, sample_count, cyclic) };
         if buf.is_null() { bail!(SysError(Errno::last())); }
-        Ok(Buffer { buf, })
+        Ok(Buffer { buf, ctx: self.context() })
     }
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -16,4 +16,3 @@ error_chain! {
         Nix(::nix::Error);
     }
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,28 +21,26 @@ extern crate libiio_sys as ffi;
 use std::ffi::CStr;
 use std::os::raw::c_char;
 
+pub use buffer::*;
+pub use channel::*;
 pub use context::*;
 pub use device::*;
-pub use channel::*;
-pub use buffer::*;
 pub use errors::*;
 
+pub mod buffer;
+pub mod channel;
 pub mod context;
 pub mod device;
-pub mod channel;
-pub mod buffer;
 pub mod errors;
 
 fn cstring_opt(pstr: *const c_char) -> Option<String> {
     if pstr.is_null() {
         None
-    }
-    else {
+    } else {
         let name = unsafe { CStr::from_ptr(pstr) };
         Some(name.to_str().unwrap_or_default().to_string())
     }
 }
-
 
 // --------------------------------------------------------------------------
 


### PR DESCRIPTION
Hello!
I have been using this crate for some prototype work.  Thanks!  I ran into issues with runtime crashes due to Context structs being dropped while there were still Device and Channel structs alive which (internally within libiio) still referred to the iio_context.  I took some time to do some internal refactoring to add reference counting so that this crash would be impossible.  I think it slightly improves the ergonomics as well, as the user need not keep around a Context object if they don't want it.
I removed some APIs which were not immediately easy to port to this new scheme.  See the commit comments for more info.
I hope this is useful!