### PR TITLE
Extended error handling for device sample rates

### DIFF
--- a/examples/riio_bufavg.rs
+++ b/examples/riio_bufavg.rs
@@ -270,13 +270,13 @@ fn main() {
         } else {
             eprintln!("{} {}", "Can't set sampling frequency! No suitable",
                 "attribute found in specified device and trigger...");
-            eprintln!("Sample rate not set... Continuing");
+            process::exit(2);
         }
     }
 
     dev.set_trigger(&trig).unwrap_or_else(|err| {
         println!("Error setting the trigger in the device: {}", err);
-        process::exit(2);
+        process::exit(3);
     });
 
     // ----- Create a buffer -----
@@ -288,7 +288,7 @@ fn main() {
 
     let mut buf = dev.create_buffer(n_sample, false).unwrap_or_else(|err| {
         eprintln!("Unable to create buffer: {}", err);
-        process::exit(3);
+        process::exit(4);
     });
 
     // Make sure the timeout is more than enough to gather each buffer

--- a/examples/riio_tsbuf.rs
+++ b/examples/riio_tsbuf.rs
@@ -128,24 +128,44 @@ fn main() {
 
     // ----- Set a trigger -----
 
-    let trig = ctx.find_device(trig_name).unwrap_or_else(|| {
-        eprintln!("Couldn't find requested trigger: {}", trig_name);
-        process::exit(1);
-    });
-
     let freq = matches
         .value_of("frequency")
         .and_then(|s| s.parse::<i64>().ok())
         .unwrap_or(DFLT_FREQ);
 
-    // Set the sampling rate
-    if let Err(err) = trig.attr_write_int("sampling_frequency", freq) {
-        println!("Can't set sampling rate to {}Hz: {}", freq, err);
+    let trig = ctx.find_device(trig_name).unwrap_or_else(|| {
+        eprintln!("Couldn't find requested trigger: {}", trig_name);
+        process::exit(1);
+    });
+
+    // There is no unified way to handle setting sample rates across iio
+    // devices. Thus we have to do this handling ourselves.
+    // Set the sampling rate on the trigger
+    if trig.has_attr("sampling_frequency") {
+        if let Err(err) = trig.attr_write_int("sampling_frequency", freq) {
+            eprintln!("Can't set sampling rate to {}Hz on {}: '{}'", 
+                freq, trig.name().unwrap(), err);
+        }
+    } else {
+        println!("{} {}", "Trigger doesn't have sampling frequency attribute!",
+            "Setting on device instead");
+
+        if dev.has_attr("sampling_frequency") {
+            // Set the sampling rate on the device
+            if let Err(err) = dev.attr_write_int("sampling_frequency", freq) {
+                eprintln!("Can't set sampling rate to {}Hz on {}: '{}'", 
+                    freq, dev.name().unwrap(), err);
+            }
+        } else {
+            eprintln!("{} {}", "Can't set sampling frequency! No suitable",
+                "attribute found in specified device and trigger...");
+            process::exit(2);
+        }
     }
 
     dev.set_trigger(&trig).unwrap_or_else(|err| {
         println!("Error setting the trigger in the device: {}", err);
-        process::exit(2);
+        process::exit(3);
     });
 
     // ----- Create a buffer -----
@@ -157,7 +177,7 @@ fn main() {
 
     let mut buf = dev.create_buffer(n_sample, false).unwrap_or_else(|err| {
         eprintln!("Unable to create buffer: {}", err);
-        process::exit(3);
+        process::exit(4);
     });
 
     // Make sure the timeout is more than enough to gather each buffer
@@ -172,7 +192,7 @@ fn main() {
     println!("Capturing a buffer...");
     if let Err(err) = buf.refill() {
         eprintln!("Error filling the buffer: {}", err);
-        process::exit(4);
+        process::exit(5);
     }
 
     // Extract and print the data


### PR DESCRIPTION
Setting the sample rate for a device isn't a strictly normed operation in IIO. The examples previously relied on the trigger for a device to expose the `sampling_frequency` attribute that sets the sample frequency. However, this assumption doesn't hold for all sensors in the kernel. Some expose the `sampling_frequency` attribute on the device itself instead of the trigger.

These patches add some error handling to take care of these cases. If the `sampling_frequency` attribute can't be found on the device or its respective trigger, an error is thrown.