### PR TITLE
Rework context construction

### DIFF
--- a/examples/riio_bufavg.rs
+++ b/examples/riio_bufavg.rs
@@ -181,13 +181,13 @@ fn main() {
     let trig_name = matches.value_of("trigger").unwrap_or(DFLT_TRIG_NAME);
 
     let mut ctx = if let Some(hostname) = matches.value_of("host") {
-        iio::Context::create_network(hostname)
+        iio::Context::new(iio::Backend::Ip(hostname))
     }
     else if let Some(uri) = matches.value_of("uri") {
-        iio::Context::create_from_uri(uri)
+        iio::Context::new(iio::Backend::FromUri(uri))
     }
     else {
-        iio::Context::new()
+        iio::Context::default()
     }
     .unwrap_or_else(|_err| {
         println!("Couldn't open IIO context.");

--- a/examples/riio_detect.rs
+++ b/examples/riio_detect.rs
@@ -42,13 +42,13 @@ fn main() {
         .get_matches();
 
     let ctx = if let Some(hostname) = matches.value_of("network") {
-        iio::Context::create_network(hostname)
+        iio::Context::new(iio::Backend::Ip(hostname))
     }
     else if let Some(uri) = matches.value_of("uri") {
-        iio::Context::create_from_uri(uri)
+        iio::Context::new(iio::Backend::FromUri(uri))
     }
     else {
-        iio::Context::new()
+        iio::Context::default()
     }
     .unwrap_or_else(|_err| {
         println!("Couldn't open IIO context.");

--- a/examples/riio_free_scan.rs
+++ b/examples/riio_free_scan.rs
@@ -51,13 +51,13 @@ fn main() {
     let dev_name = matches.value_of("device").unwrap_or(DFLT_DEV_NAME);
 
     let ctx = if let Some(hostname) = matches.value_of("network") {
-        iio::Context::create_network(hostname)
+        iio::Context::new(iio::Backend::Ip(hostname))
     }
     else if let Some(uri) = matches.value_of("uri") {
-        iio::Context::create_from_uri(uri)
+        iio::Context::new(iio::Backend::FromUri(uri))
     }
     else {
-        iio::Context::new()
+        iio::Context::default()
     }
     .unwrap_or_else(|_err| {
         println!("Couldn't open IIO context.");

--- a/examples/riio_readraw.rs
+++ b/examples/riio_readraw.rs
@@ -54,13 +54,13 @@ fn main() -> iio::Result<()> {
         .get_matches();
 
     let ctx = if let Some(hostname) = matches.value_of("network") {
-        iio::Context::create_network(hostname)
+        iio::Context::new(iio::Backend::Ip(hostname))
     }
     else if let Some(uri) = matches.value_of("uri") {
-        iio::Context::create_from_uri(uri)
+        iio::Context::new(iio::Backend::FromUri(uri))
     }
     else {
-        iio::Context::new()
+        iio::Context::default()
     }
     .unwrap_or_else(|_err| {
         println!("Couldn't open IIO context.");

--- a/examples/riio_tsbuf.rs
+++ b/examples/riio_tsbuf.rs
@@ -93,13 +93,13 @@ fn main() {
     let trig_name = matches.value_of("trigger").unwrap_or(DFLT_TRIG_NAME);
 
     let mut ctx = if let Some(hostname) = matches.value_of("host") {
-        iio::Context::create_network(hostname)
+        iio::Context::new(iio::Backend::Ip(hostname))
     }
     else if let Some(uri) = matches.value_of("uri") {
-        iio::Context::create_from_uri(uri)
+        iio::Context::new(iio::Backend::FromUri(uri))
     }
     else {
-        iio::Context::new()
+        iio::Context::default()
     }
     .unwrap_or_else(|_err| {
         println!("Couldn't open IIO context.");

--- a/src/context.rs
+++ b/src/context.rs
@@ -37,38 +37,38 @@ pub struct Context {
 }
 
 /// Backends for I/O Contexts.
-/// 
+///
 /// An I/O [`Context`] relies on a backend that provides sensor data.
 #[derive(Debug)]
 pub enum Backend<'a> {
-    /// Local Backend, only available on Linux hosts. Sensors to work with are 
+    /// Local Backend, only available on Linux hosts. Sensors to work with are
     /// part of the system and accessible in sysfs (under `/sys/...`).
     Local,
-    /// XML Backend, creates a Context from an XML file. Example Parameter: 
+    /// XML Backend, creates a Context from an XML file. Example Parameter:
     /// "/home/user/file.xml"
     Xml(&'a str),
-    /// Network Backend, creates a Context through a network connection. 
-    /// Requires a hostname, IPv4 or IPv6 address to connect to another host 
-    /// that is running the [IIO Daemon]. If an empty string is provided, 
+    /// Network Backend, creates a Context through a network connection.
+    /// Requires a hostname, IPv4 or IPv6 address to connect to another host
+    /// that is running the [IIO Daemon]. If an empty string is provided,
     /// automatic discovery through ZeroConf is performed (if available in IIO).
     /// Example Parameter:
-    /// 
+    ///
     /// - "192.168.2.1" to connect to given IPv4 host, **or**
     /// - "localhost" to connect to localhost running IIOD, **or**
     /// - "plutosdr.local" to connect to host with given hostname, **or**
     /// - "" for automatic discovery
-    /// 
+    ///
     /// [IIO Daemon]: https://github.com/analogdevicesinc/libiio/tree/master/iiod
     Ip(&'a str),
     /// USB Backend, creates a context through a USB connection.
-    /// If only a single USB device is attached, provide an empty String ("") 
-    /// to use that. When more than one usb device is attached, requires bus, 
-    /// address, and interface parts separated with a dot. 
+    /// If only a single USB device is attached, provide an empty String ("")
+    /// to use that. When more than one usb device is attached, requires bus,
+    /// address, and interface parts separated with a dot.
     /// Example Parameter: "3.32.5"
     Usb(&'a str),
     /// Serial Backend, creates a context through a serial connection.
     /// Requires (Values in parentheses show examples):
-    /// 
+    ///
     /// - a port (/dev/ttyUSB0),
     /// - baud_rate (default 115200)
     /// - serial port configuration
@@ -76,17 +76,17 @@ pub enum Backend<'a> {
     ///     - parity ('n' none, 'o' odd, 'e' even, 'm' mark, 's' space)
     ///     - stop bits (1 2)
     ///     - flow control ('\0' none, 'x' Xon Xoff, 'r' RTSCTS, 'd' DTRDSR)
-    /// 
+    ///
     /// Example Parameters:
-    /// 
+    ///
     /// - "/dev/ttyUSB0,115200", **or**
     /// - "/dev/ttyUSB0,115200,8n1"
     Serial(&'a str),
-    /// "Guess" the backend to use from the URI that's supplied. This merely 
-    /// provides compatibility with [`iio_create_context_from_uri`] from the 
-    /// underlying IIO C-library. Refer to the IIO docs for information on how 
+    /// "Guess" the backend to use from the URI that's supplied. This merely
+    /// provides compatibility with [`iio_create_context_from_uri`] from the
+    /// underlying IIO C-library. Refer to the IIO docs for information on how
     /// to format this parameter.
-    /// 
+    ///
     /// [`iio_create_context_from_uri`]: https://analogdevicesinc.github.io/libiio/master/libiio/group__Context.html#gafdcee40508700fa395370b6c636e16fe
     FromUri(&'a str)
 }
@@ -106,41 +106,41 @@ impl Drop for InnerContext {
 
 impl Context {
     /// Create an IIO Context.
-    /// 
-    /// A context contains one or more devices (i.e. sensors) that can provide 
-    /// data. Note that any device can always only be associated with one 
+    ///
+    /// A context contains one or more devices (i.e. sensors) that can provide
+    /// data. Note that any device can always only be associated with one
     /// context!
-    /// 
-    /// Contexts rely on [`Backend`]s to discover available sensors. Multiple 
+    ///
+    /// Contexts rely on [`Backend`]s to discover available sensors. Multiple
     /// [`Backend`]s are supported.
-    /// 
+    ///
     /// # Examples
-    /// 
-    /// Create a context to work with sensors on the local system 
+    ///
+    /// Create a context to work with sensors on the local system
     /// (Only supported for Linux hosts):
-    /// 
+    ///
     /// ```no_run
     /// use industrial_io as iio;
-    /// 
+    ///
     /// let ctx = iio::Context::new(iio::Backend::Local);
     /// ```
-    /// 
+    ///
     /// Create a context that works with senors on some network host:
-    /// 
+    ///
     /// ```no_run
     /// use industrial_io as iio;
-    /// 
+    ///
     /// let ctx_ip = iio::Context::new(iio::Backend::Ip("192.168.2.1"));
     /// let ctx_host = iio::Context::new(iio::Backend::Ip("runs-iiod.local"));
     /// let ctx_auto = iio::Context::new(iio::Backend::Ip())
     /// ```
-    /// 
-    /// Creates a Context using some arbitrary URI (like it is used in the 
+    ///
+    /// Creates a Context using some arbitrary URI (like it is used in the
     /// underlying IIO C-library):
-    /// 
+    ///
     /// ```no_run
     /// use industrial_io as iio;
-    /// 
+    ///
     /// let ctx = iio::Context::new(iio::Backend::FromUri("ip:192.168.2.1"));
     /// ```
     pub fn new(be: Backend) -> Result<Context> {
@@ -181,8 +181,8 @@ impl Context {
 
     /// Creates a default context from a local or remote IIO device.
     ///
-    /// # Notes 
-    /// 
+    /// # Notes
+    ///
     /// This will create a network context if the IIOD_REMOTE
     /// environment variable is set to the hostname where the IIOD server
     /// runs. If set to an empty string, the server will be discovered using

--- a/src/context.rs
+++ b/src/context.rs
@@ -36,6 +36,61 @@ pub struct Context {
     inner: Rc<InnerContext>,
 }
 
+/// Backends for I/O Contexts.
+/// 
+/// An I/O [`Context`] relies on a backend that provides sensor data.
+#[derive(Debug)]
+pub enum Backend<'a> {
+    /// Local Backend, only available on Linux hosts. Sensors to work with are 
+    /// part of the system and accessible in sysfs (under `/sys/...`).
+    Local,
+    /// XML Backend, creates a Context from an XML file. Example Parameter: 
+    /// "/home/user/file.xml"
+    Xml(&'a str),
+    /// Network Backend, creates a Context through a network connection. 
+    /// Requires a hostname, IPv4 or IPv6 address to connect to another host 
+    /// that is running the [IIO Daemon]. If an empty string is provided, 
+    /// automatic discovery through ZeroConf is performed (if available in IIO).
+    /// Example Parameter:
+    /// 
+    /// - "192.168.2.1" to connect to given IPv4 host, **or**
+    /// - "localhost" to connect to localhost running IIOD, **or**
+    /// - "plutosdr.local" to connect to host with given hostname, **or**
+    /// - "" for automatic discovery
+    /// 
+    /// [IIO Daemon]: https://github.com/analogdevicesinc/libiio/tree/master/iiod
+    Ip(&'a str),
+    /// USB Backend, creates a context through a USB connection.
+    /// If only a single USB device is attached, provide an empty String ("") 
+    /// to use that. When more than one usb device is attached, requires bus, 
+    /// address, and interface parts separated with a dot. 
+    /// Example Parameter: "3.32.5"
+    Usb(&'a str),
+    /// Serial Backend, creates a context through a serial connection.
+    /// Requires (Values in parentheses show examples):
+    /// 
+    /// - a port (/dev/ttyUSB0),
+    /// - baud_rate (default 115200)
+    /// - serial port configuration
+    ///     - data bits (5 6 7 8 9)
+    ///     - parity ('n' none, 'o' odd, 'e' even, 'm' mark, 's' space)
+    ///     - stop bits (1 2)
+    ///     - flow control ('\0' none, 'x' Xon Xoff, 'r' RTSCTS, 'd' DTRDSR)
+    /// 
+    /// Example Parameters:
+    /// 
+    /// - "/dev/ttyUSB0,115200", **or**
+    /// - "/dev/ttyUSB0,115200,8n1"
+    Serial(&'a str),
+    /// "Guess" the backend to use from the URI that's supplied. This merely 
+    /// provides compatibility with [`iio_create_context_from_uri`] from the 
+    /// underlying IIO C-library. Refer to the IIO docs for information on how 
+    /// to format this parameter.
+    /// 
+    /// [`iio_create_context_from_uri`]: https://analogdevicesinc.github.io/libiio/master/libiio/group__Context.html#gafdcee40508700fa395370b6c636e16fe
+    FromUri(&'a str)
+}
+
 /// This holds a pointer to the library context.
 /// When it is dropped, the library context is destroyed.
 #[derive(Debug)]

--- a/src/context.rs
+++ b/src/context.rs
@@ -179,34 +179,17 @@ impl Context {
         })
     }
 
-    /// Creates a context from a local device (Linux only)
-    #[cfg(target_os = "linux")]
-    pub fn create_local() -> Result<Context> {
-        let ctx = unsafe { ffi::iio_create_local_context() };
-        if ctx.is_null() {
-            return Err(Errno::last().into());
-        }
-        Ok(Context {
-            inner: Rc::new(InnerContext { ctx }),
-        })
-    }
-
-    /// Creates a context from a network device
-    pub fn create_network(host: &str) -> Result<Context> {
-        let host = CString::new(host)?;
-        let ctx = unsafe { ffi::iio_create_network_context(host.as_ptr()) };
-        if ctx.is_null() {
-            return Err(Errno::last().into());
-        }
-        Ok(Context {
-            inner: Rc::new(InnerContext { ctx }),
-        })
-    }
-
-    /// Creates a context from an XML file
-    pub fn create_xml(xml_file: &str) -> Result<Context> {
-        let xml_file = CString::new(xml_file)?;
-        let ctx = unsafe { ffi::iio_create_xml_context(xml_file.as_ptr()) };
+    /// Creates a default context from a local or remote IIO device.
+    ///
+    /// # Notes 
+    /// 
+    /// This will create a network context if the IIOD_REMOTE
+    /// environment variable is set to the hostname where the IIOD server
+    /// runs. If set to an empty string, the server will be discovered using
+    /// ZeroConf. If the environment variable is not set, a local context
+    /// will be created instead.
+    pub fn default() -> Result<Context> {
+        let ctx = unsafe { ffi::iio_create_default_context() };
         if ctx.is_null() {
             return Err(Errno::last().into());
         }


### PR DESCRIPTION
Hello,


this is an attempt to "streamline" the default Context construction. I don't mean to be rude, but from what I've seen so far, the usual way to generate instances of "objects" is by defining a `new` function/method. I thought that as this is a Rust library, maybe it could use a more Rust-specific way of instantiating objects... ? 

Personally, as a newcomer that hasn't worked with the IIO C-library before, I found it really confusing that there are 5 or 6 different functions to generate a context. So I added an Enum for the various backend types that IIO understands and pass these as parameter to the `new` function.

I'm aware that this is a breaking change with respect to the current interface. Curious to hear your thoughts on the issue!


Cheers,
Andreas