### PR TITLE
Disable chrono default features to mitigate segfault potential in time crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
      - `Context::try_release_inner()` attempts to get the inner context out of the context wrapper.
      - `Context::try_deep_clone()` to make a new context around a deep copy of the inner context (and thus a copy of the C lib context).
      - `From<InnerContext> for Context`
+- Updates to dependencies with security issues:
+  - `chrono v0.4.19` is dependent on `time v0.1.44` which is vulnerable to [RUSTSEC-2020-0071](https://rustsec.org/advisories/RUSTSEC-2020-0071.html).  Disabling the default features will mitigate the issue until `chrono` updates its own dependencies.
 
 ###  [v0.4.0](https://github.com/fpagliughi/rust-industrial-io/compare/v0.3..v0.4.0) - 2022-01-28
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,6 @@ clap = "2.34"
 
 [dev-dependencies]
 schedule_recv = "0.1"
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false }
 ctrlc = "3.2"
 anyhow = "1.0"


### PR DESCRIPTION
Running `cargo audit` in this crate reveals that there is a [potential segfault](https://rustsec.org/advisories/RUSTSEC-2020-0071.html) in `time v0.1.44`.  This is caused by the `chrono v0.4.19` dependency pulling in `time v0.1.44` as part of its default features.  This PR disables chrono's default features in dev-dependencies to get around the issue, as `chrono` has not updated its own `time` dependency yet.