### PR TITLE
Added `#[must_use]` attribute, and const to functions where possible. Derivedd Eq besides PartialEq where possible. Removed structure name repition.

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -80,12 +80,14 @@ impl Buffer {
     ///
     /// Get the buffer capacity in number of samples from each channel that
     /// the buffer can hold.
-    pub fn capacity(&self) -> usize {
+    #[must_use]
+    pub const fn capacity(&self) -> usize {
         self.cap
     }
 
     /// Gets a reference to the device to which this buffer is attached.
-    pub fn device(&self) -> &Device {
+    #[must_use]
+    pub const fn device(&self) -> &Device {
         &self.dev
     }
 
@@ -160,11 +162,13 @@ impl Buffer {
     }
 
     /// Determines if the device has any buffer-specific attributes
+    #[must_use]
     pub fn has_attrs(&self) -> bool {
         unsafe { ffi::iio_device_get_buffer_attrs_count(self.dev.dev) > 0 }
     }
 
     /// Gets the number of buffer-specific attributes
+    #[must_use]
     pub fn num_attrs(&self) -> usize {
         unsafe { ffi::iio_device_get_buffer_attrs_count(self.dev.dev) as usize }
     }
@@ -176,6 +180,7 @@ impl Buffer {
     }
 
     /// Try to find a buffer-specific attribute by its name
+    #[must_use]
     pub fn find_attr(&self, name: &str) -> Option<String> {
         let cname = cstring_or_bail!(name);
         let pstr = unsafe { ffi::iio_device_find_buffer_attr(self.dev.dev, cname.as_ptr()) };
@@ -183,6 +188,7 @@ impl Buffer {
     }
 
     /// Determines if a buffer-specific attribute exists
+    #[must_use]
     pub fn has_attr(&self, name: &str) -> bool {
         let cname = cstring_or_bail_false!(name);
         let pstr = unsafe { ffi::iio_device_find_buffer_attr(self.dev.dev, cname.as_ptr()) };
@@ -323,7 +329,8 @@ impl Buffer {
     }
 
     /// Gets an iterator for the buffer attributes in the device
-    pub fn attributes(&self) -> AttrIterator {
+    #[must_use]
+    pub const fn attributes(&self) -> AttrIterator {
         AttrIterator { buf: self, idx: 0 }
     }
 
@@ -334,6 +341,7 @@ impl Buffer {
     }
 
     /// Gets an iterator for the data from a channel.
+    #[must_use]
     pub fn channel_iter<T>(&self, chan: &Channel) -> IntoIter<T> {
         unsafe {
             let begin = ffi::iio_buffer_first(self.buf, chan.chan).cast();

--- a/src/context.rs
+++ b/src/context.rs
@@ -251,6 +251,7 @@ impl Context {
     }
 
     /// Creates a context from an existing "inner" object.
+    #[must_use]
     pub fn from_inner(inner: InnerContext) -> Self {
         Self::from(inner)
     }
@@ -291,18 +292,21 @@ impl Context {
 
     /// Get the name of the context.
     /// This should be "local", "xml", or "network" depending on how the context was created.
+    #[must_use]
     pub fn name(&self) -> String {
         let pstr = unsafe { ffi::iio_context_get_name(self.inner.ctx) };
         cstring_opt(pstr).unwrap_or_default()
     }
 
     /// Get a description of the context
+    #[must_use]
     pub fn description(&self) -> String {
         let pstr = unsafe { ffi::iio_context_get_description(self.inner.ctx) };
         cstring_opt(pstr).unwrap_or_default()
     }
 
     /// Get the version of the backend in use
+    #[must_use]
     pub fn version(&self) -> Version {
         let mut major: c_uint = 0;
         let mut minor: c_uint = 0;
@@ -330,17 +334,20 @@ impl Context {
     }
 
     /// Obtain the XML representation of the context.
+    #[must_use]
     pub fn xml(&self) -> String {
         let pstr = unsafe { ffi::iio_context_get_xml(self.inner.ctx) };
         cstring_opt(pstr).unwrap_or_default()
     }
 
     /// Determines if the context has any attributes
+    #[must_use]
     pub fn has_attrs(&self) -> bool {
         unsafe { ffi::iio_context_get_attrs_count(self.inner.ctx) > 0 }
     }
 
     /// Gets the number of context-specific attributes
+    #[must_use]
     pub fn num_attrs(&self) -> usize {
         let n = unsafe { ffi::iio_context_get_attrs_count(self.inner.ctx) };
         n as usize
@@ -369,7 +376,8 @@ impl Context {
     }
 
     /// Gets an iterator for the attributes in the context
-    pub fn attributes(&self) -> AttrIterator {
+    #[must_use]
+    pub const fn attributes(&self) -> AttrIterator {
         AttrIterator { ctx: self, idx: 0 }
     }
 
@@ -392,6 +400,7 @@ impl Context {
     }
 
     /// Get the number of devices in the context
+    #[must_use]
     pub fn num_devices(&self) -> usize {
         unsafe { ffi::iio_context_get_devices_count(self.inner.ctx) as usize }
     }
@@ -410,6 +419,7 @@ impl Context {
 
     /// Try to find a device by name or ID
     /// `name` The name or ID of the device to find
+    #[must_use]
     pub fn find_device(&self, name: &str) -> Option<Device> {
         let name = CString::new(name).unwrap();
         let dev = unsafe { ffi::iio_context_find_device(self.inner.ctx, name.as_ptr()) };
@@ -425,7 +435,8 @@ impl Context {
     }
 
     /// Gets an iterator for all the devices in the context.
-    pub fn devices(&self) -> DeviceIterator {
+    #[must_use]
+    pub const fn devices(&self) -> DeviceIterator {
         DeviceIterator { ctx: self, idx: 0 }
     }
 

--- a/src/device.rs
+++ b/src/device.rs
@@ -33,17 +33,20 @@ pub struct Device {
 
 impl Device {
     /// Gets the context to which the device belongs
+    #[must_use]
     pub fn context(&self) -> Context {
         self.ctx.clone()
     }
 
     /// Gets the device ID (e.g. <b><i>iio:device0</i></b>)
+    #[must_use]
     pub fn id(&self) -> Option<String> {
         let pstr = unsafe { ffi::iio_device_get_id(self.dev) };
         cstring_opt(pstr)
     }
 
     /// Gets the name of the device
+    #[must_use]
     pub fn name(&self) -> Option<String> {
         let pstr = unsafe { ffi::iio_device_get_name(self.dev) };
         cstring_opt(pstr)
@@ -51,6 +54,7 @@ impl Device {
 
     /// Determines if the device is capable of buffered I/O.
     /// This is true if any of the channels are scan elements.
+    #[must_use]
     pub fn is_buffer_capable(&self) -> bool {
         // This "trick" is from C lib 'iio_info.c'
         for chan in self.channels() {
@@ -62,6 +66,7 @@ impl Device {
     }
 
     /// Determines whether the device is a trigger
+    #[must_use]
     pub fn is_trigger(&self) -> bool {
         unsafe { ffi::iio_device_is_trigger(self.dev) }
     }
@@ -82,11 +87,13 @@ impl Device {
     // ----- Attributes -----
 
     /// Determines if the device has any attributes
+    #[must_use]
     pub fn has_attrs(&self) -> bool {
         unsafe { ffi::iio_device_get_attrs_count(self.dev) > 0 }
     }
 
     /// Gets the number of device-specific attributes
+    #[must_use]
     pub fn num_attrs(&self) -> usize {
         unsafe { ffi::iio_device_get_attrs_count(self.dev) as usize }
     }
@@ -98,6 +105,7 @@ impl Device {
     }
 
     /// Try to find a device-specific attribute by its name
+    #[must_use]
     pub fn find_attr(&self, name: &str) -> Option<String> {
         let cname = cstring_or_bail!(name);
         let pstr = unsafe { ffi::iio_device_find_attr(self.dev, cname.as_ptr()) };
@@ -105,6 +113,7 @@ impl Device {
     }
 
     /// Determines if a buffer-specific attribute exists
+    #[must_use]
     pub fn has_attr(&self, name: &str) -> bool {
         let cname = cstring_or_bail_false!(name);
         let pstr = unsafe { ffi::iio_device_find_attr(self.dev, cname.as_ptr()) };
@@ -228,13 +237,15 @@ impl Device {
     }
 
     /// Gets an iterator for the attributes in the device
-    pub fn attributes(&self) -> AttrIterator {
+    #[must_use]
+    pub const fn attributes(&self) -> AttrIterator {
         AttrIterator { dev: self, idx: 0 }
     }
 
     // ----- Channels -----
 
     /// Gets the number of channels on the device
+    #[must_use]
     pub fn num_channels(&self) -> usize {
         unsafe { ffi::iio_device_get_channels_count(self.dev) as usize }
     }
@@ -252,6 +263,7 @@ impl Device {
     }
 
     /// Try to find a channel by its name or ID
+    #[must_use]
     pub fn find_channel(&self, name: &str, is_output: bool) -> Option<Channel> {
         let cname = cstring_or_bail!(name);
         let chan = unsafe { ffi::iio_device_find_channel(self.dev, cname.as_ptr(), is_output) };
@@ -268,7 +280,8 @@ impl Device {
     }
 
     /// Gets an iterator for the channels in the device
-    pub fn channels(&self) -> ChannelIterator {
+    #[must_use]
+    pub const fn channels(&self) -> ChannelIterator {
         ChannelIterator { dev: self, idx: 0 }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,7 +177,7 @@ pub(crate) unsafe extern "C" fn attr_read_all_cb(
 // --------------------------------------------------------------------------
 
 /// A struct to hold version numbers
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Version {
     /// The Major version number
     pub major: u32,
@@ -196,6 +196,7 @@ impl fmt::Display for Version {
 // --------------------------------------------------------------------------
 
 /// Gets the library version as (Major, Minor, Git Tag)
+#[must_use]
 pub fn library_version() -> Version {
     let mut major: c_uint = 0;
     let mut minor: c_uint = 0;


### PR DESCRIPTION
Added `#[must_use]` attribute, and const to functions where possible. Derivedd Eq besides PartialEq where possible. Removed structure name repition.