### PR TITLE
Added 'binary' feature to reduce lib dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,25 @@ Linux Industrial I/O (IIO) Support
 libiio-sys = { version = "0.3", path = "libiio-sys" }
 thiserror = "1.0"
 nix = "0.23"
-clap = "2.34"
+clap = { version = "2.34", optional = true }
 
 [dev-dependencies]
 schedule_recv = "0.1"
 chrono = "0.4"
 ctrlc = "3.2"
 anyhow = "1.0"
+clap = "2.34"
+
+[features]
+default = ["utilities"]
+utilities = ["clap"]
+
+# ----- Utilities -----
+
+[[bin]]
+name = "iio_info_rs"
+required-features = ["utilities"]
+
+[[bin]]
+name = "riio_stop_all"
+required-features = ["utilities"]

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ To keep up with the latest announcements for this project, follow:
 ### Unreleased Features in This Branch
 
 - [#21](https://github.com/fpagliughi/rust-industrial-io/issues/21) Updated the nix dependency to the latest verison (v0.23)
+- Create separate on-by-default 'utilities' feature to reduce dependencies for lib-only builds
 
 ### New in Version 0.5.1
 
@@ -241,10 +242,16 @@ $ iiod --version
 
 ## Build the Rust Crate
 
-This is a fairly standard Rust wrapper project around a C library. It contains an unsafe _"-sys"_ sub-crate to wrap the C library API, and a higher-level, safe, Rust library in the main crate. To build them:
+This is a fairly standard Rust wrapper project around a C library. It contains an unsafe _"-sys"_ sub-crate to wrap the C library API, and a higher-level, safe, Rust library in the main crate. The crate also contains utilities that interface with IIO devices via the library. To build the library and utilities:
 
 ```
 $ cargo build
+```
+
+The library can be built with fewer dependencies. To build just the library:
+
+```
+$ cargo build --lib --no-default-features
 ```
 
 There are also a number of example applications. They can all be built with:


### PR DESCRIPTION
I have an application which depends on `rust-industrial-io` and I'm looking to improve its build time. I noticed that this crate pulls in `clap`, but it is only needed for `iio_info_rs` binary, and I only depend on the libraries. On my machine this reduces the lib-only build time from ~6.3 to ~5 seconds and removes several dependencies.

I'm not sure if this is the best way to separate dependencies by binary vs. library builds. It looks like there is an RFC https://github.com/rust-lang/rfcs/pull/3374 to provide a better way to do this, but I think this is the best that exists right now.