### PR TITLE
Added method to get mutable slice of channel buffer

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -349,6 +349,23 @@ impl Buffer {
             }
         }
     }
+
+    /// Gets a mutable slice for the data from a channel.
+    pub fn channel_slice_mut<T>(&mut self, chan: &Channel) -> Option<&mut [T]> {
+        unsafe {
+            let begin = ffi::iio_buffer_first(self.buf, chan.chan) as *mut T;
+
+            if begin.is_null() {
+                None
+            } else {
+                let end = ffi::iio_buffer_end(self.buf) as *mut T;
+                let ptr = begin;
+                let size = end.offset_from(begin).abs() as usize;
+
+                Some(std::slice::from_raw_parts_mut(ptr, size))
+            }
+        }
+    }
 }
 
 /// Destroy the underlying buffer when the object scope ends.


### PR DESCRIPTION
The library is missing a way to write data to buffers (or am I missing something?).

I added a method that returns a mutable slice to the buffer data. It's wrapped in an `Option` because `iio_buffer_start()` may return `NULL`.