### PR TITLE
Move set_num_kernel_buffers() to Device

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -327,12 +327,6 @@ impl Buffer {
         AttrIterator { buf: self, idx: 0 }
     }
 
-    /// Set the number of kernel buffers for the device.
-    pub fn set_num_kernel_buffers(&self, n: u32) -> Result<()> {
-        let ret = unsafe { ffi::iio_device_set_kernel_buffers_count(self.dev.dev, n as c_uint) };
-        sys_result(ret, ())
-    }
-
     /// Gets an iterator for the data from a channel.
     pub fn channel_iter<T>(&self, chan: &Channel) -> IntoIter<T> {
         unsafe {

--- a/src/device.rs
+++ b/src/device.rs
@@ -86,6 +86,12 @@ impl Device {
         sys_result(ret, ())
     }
 
+    /// Set the number of kernel buffers for the device.
+    pub fn set_num_kernel_buffers(&self, n: u32) -> Result<()> {
+        let ret = unsafe { ffi::iio_device_set_kernel_buffers_count(self.dev, n as c_uint) };
+        sys_result(ret, ())
+    }
+
     // ----- Attributes -----
 
     /// Determines if the device has any attributes


### PR DESCRIPTION
Calling `iio_device_set_kernel_buffers_count()` after creating an IIO buffer returns `EBUSY`. Since `set_num_kernel_buffers()` is a method on `Buffer` it will never run successfully.

This PR moves it to `Device` to fix this.