### PR TITLE
Fix build script platform behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
     - clap v4.4
     - thiserror v2.0
 - [PR #32](https://github.com/fpagliughi/rust-industrial-io/pull/32) Typo in `ChannelType::Light`
+- [PR #33](https://github.com/fpagliughi/rust-industrial-io/pull/33) Fix build script platform behavior
 
 
 ### [v0.6.0](https://github.com/fpagliughi/rust-industrial-io/compare/v0.5.2..v0.6.0) - 2024-12-10

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "industrial-io"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 rust-version = "1.73.0"
 authors = ["Frank Pagliughi <fpagliughi@mindspring.com>"]

--- a/libiio-sys/Cargo.toml
+++ b/libiio-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libiio-sys"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 rust-version = "1.73.0"
 authors = ["Frank Pagliughi <fpagliughi@mindspring.com>"]

--- a/libiio-sys/build.rs
+++ b/libiio-sys/build.rs
@@ -12,7 +12,6 @@
 
 use std::env;
 
-#[cfg(target_os = "macos")]
 fn config_macos() {
     println!("cargo:rustc-link-lib=framework=iio");
 
@@ -42,9 +41,12 @@ fn main() {
     #[cfg(feature = "libiio_v0_21")]
     println!("debug: Using bindings for libiio v0.21");
 
-    #[cfg(not(target_os = "macos"))]
-    println!("cargo:rustc-link-lib=iio");
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
 
-    #[cfg(target_os = "macos")]
-    config_macos();
+    if target_os == "linux" {
+        println!("cargo:rustc-link-lib=iio");
+    }
+    else if target_os == "macos" {
+        config_macos();
+    }
 }


### PR DESCRIPTION
The old method used `cfg` directives based on target architecture. This was not correct, as the build script is always built for the host architecture. Instead, the build script should use the environment variable provided by cargo to detect the architecture for which the associated crate will be built.